### PR TITLE
feat: verify foundry binaries util

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ import { getClientVersion } from './getClientVersion';
 import { getRollupCreatorAddress } from './getRollupCreatorAddress';
 import { getTokenBridgeCreatorAddress } from './getTokenBridgeCreatorAddress';
 import { getWethAddress } from './getWethAddress';
+import { verifyFoundryBinaries } from './verifyFoundry';
 
 export {
   generateChainId,
@@ -18,4 +19,5 @@ export {
   getRollupCreatorAddress,
   getTokenBridgeCreatorAddress,
   getWethAddress,
+  verifyFoundryBinaries,
 };

--- a/src/utils/verifyFoundry.ts
+++ b/src/utils/verifyFoundry.ts
@@ -1,0 +1,33 @@
+import { execFile } from 'node:child_process';
+
+const FOUNDRY_BINARIES: ['forge', 'cast'] = ['forge', 'cast'];
+
+function runVersionCommand(binary: 'forge' | 'cast'): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(binary, ['--version'], (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(stdout);
+    });
+  });
+}
+
+export async function verifyFoundryBinaries() {
+  const results = await Promise.allSettled(
+    FOUNDRY_BINARIES.map((binary) => runVersionCommand(binary)),
+  );
+
+  const binariesPresent = results.every((result) => result.status === 'fulfilled');
+
+  const stableReleaseInstalled = results.every(
+    (result) => result.status === 'fulfilled' && result.value.includes('-stable'),
+  );
+
+  return {
+    binariesPresent,
+    stableReleaseInstalled,
+  };
+}

--- a/src/utils/verifyFoundry.ts
+++ b/src/utils/verifyFoundry.ts
@@ -1,0 +1,47 @@
+import { execFile } from 'node:child_process';
+
+const FOUNDRY_BINARIES: ['forge', 'cast'] = ['forge', 'cast'];
+
+function runVersionCommand(binary: 'forge' | 'cast'): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(binary, ['--version'], (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(stdout);
+    });
+  });
+}
+
+export async function verifyFoundryBinaries(stableOnly = true) {
+  const results = await Promise.allSettled(
+    FOUNDRY_BINARIES.map((binary) => runVersionCommand(binary)),
+  );
+
+  const binariesPresent = results.every((result) => result.status === 'fulfilled');
+
+  const stableReleaseInstalled = results.every(
+    (result) =>
+      result.status === 'fulfilled' && result.value && isStableFoundryRelease(result.value),
+  );
+
+  if (!binariesPresent) {
+    throw new Error(
+      'Foundry is required to run this operation. Install Foundry and make sure forge and cast are available on PATH.',
+    );
+  }
+
+  if (stableOnly && !stableReleaseInstalled) {
+    throw new Error(
+      'Foundry stable releases are required to run this operation. Please install the stable versions of forge and cast.',
+    );
+  }
+}
+
+function isStableFoundryRelease(version: string): boolean {
+  return !['nightly', 'dev', 'alpha', 'beta', 'rc', 'preview'].some((tag) =>
+    version.toLowerCase().includes(tag),
+  );
+}

--- a/src/utils/verifyFoundry.ts
+++ b/src/utils/verifyFoundry.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 
-const FOUNDRY_BINARIES: ['forge', 'cast'] = ['forge', 'cast'];
+const FOUNDRY_BINARIES = ['forge', 'cast'] as const;
 
 function runVersionCommand(binary: 'forge' | 'cast'): Promise<string> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#750**
* **#748**
* **#711**
* **#746**
* **#709**
* ➡️ **#701**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


## Summary

- Add `verifyFoundryBinaries` to check whether the `forge` and `cast` executables are available.
- Detect whether both binaries report a stable Foundry release.

## Why / Context

Some SDK workflows depend on Foundry tooling being installed locally. This utility provides a lightweight preflight check that lets callers distinguish between missing Foundry binaries and installations that are not using stable releases.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
