### PR TITLE
chore: update examples to use workspace chain-sdk

### DIFF
--- a/examples/create-rollup-custom-fee-token/package.json
+++ b/examples/create-rollup-custom-fee-token/package.json
@@ -7,6 +7,9 @@
     "dev": "tsc --outDir dist && node ./dist/index.js",
     "dev:low-level": "tsc --outDir dist && node ./dist/low_level.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/create-rollup-eth/package.json
+++ b/examples/create-rollup-eth/package.json
@@ -7,6 +7,9 @@
     "dev": "tsc --outDir dist && node ./dist/index.js",
     "dev:low-level": "tsc --outDir dist && node ./dist/low_level.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/create-token-bridge-custom-fee-token/package.json
+++ b/examples/create-token-bridge-custom-fee-token/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/create-token-bridge-eth/package.json
+++ b/examples/create-token-bridge-eth/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/generate-bridge-ui-config/package.json
+++ b/examples/generate-bridge-ui-config/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/prepare-node-config/package.json
+++ b/examples/prepare-node-config/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/set-new-validators/package.json
+++ b/examples/set-new-validators/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/set-valid-keyset/package.json
+++ b/examples/set-valid-keyset/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/setup-fast-withdrawal/package.json
+++ b/examples/setup-fast-withdrawal/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/setup-fee-distributor-contract/package.json
+++ b/examples/setup-fee-distributor-contract/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/examples/upgrade-executor-add-account/package.json
+++ b/examples/upgrade-executor-add-account/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "tsc --outDir dist && node ./dist/index.js"
   },
+  "dependencies": {
+    "@arbitrum/chain-sdk": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^20.9.0",
     "typescript": "^5.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,10 @@ importers:
         version: 4.3.6
 
   examples/create-rollup-custom-fee-token:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -87,6 +91,10 @@ importers:
         version: 5.2.2
 
   examples/create-rollup-eth:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -96,6 +104,10 @@ importers:
         version: 5.2.2
 
   examples/create-token-bridge-custom-fee-token:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -105,6 +117,10 @@ importers:
         version: 5.2.2
 
   examples/create-token-bridge-eth:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -114,6 +130,10 @@ importers:
         version: 5.2.2
 
   examples/generate-bridge-ui-config:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -123,6 +143,10 @@ importers:
         version: 5.2.2
 
   examples/prepare-node-config:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -132,6 +156,10 @@ importers:
         version: 5.2.2
 
   examples/set-new-validators:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -141,6 +169,10 @@ importers:
         version: 5.2.2
 
   examples/set-valid-keyset:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -169,6 +201,10 @@ importers:
         version: 5.2.2
 
   examples/setup-fast-withdrawal:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -178,6 +214,10 @@ importers:
         version: 5.2.2
 
   examples/setup-fee-distributor-contract:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0
@@ -187,6 +227,10 @@ importers:
         version: 5.2.2
 
   examples/upgrade-executor-add-account:
+    dependencies:
+      '@arbitrum/chain-sdk':
+        specifier: workspace:*
+        version: link:../../src
     devDependencies:
       '@types/node':
         specifier: ^20.9.0


### PR DESCRIPTION
## Summary

- Add `@arbitrum/chain-sdk` as a `workspace:*` dependency to every example that did not already declare it.
- Update the pnpm lockfile so all 12 examples resolve the SDK through `link:../../src`.

## Why / Context

Examples import `@arbitrum/chain-sdk`, but most did not declare it directly. This could make them depend on incidental workspace hoisting or a published package instead of the SDK being developed locally.

Declaring the workspace dependency consistently ensures every example uses the current local SDK implementation.