### PR TITLE
fix: batch getLogs in upgradeExecutorFetchPrivilegedAccounts

### DIFF
--- a/src/upgradeExecutor.unit.test.ts
+++ b/src/upgradeExecutor.unit.test.ts
@@ -1,4 +1,4 @@
-import { it, expect } from 'vitest';
+import { it, expect, vi } from 'vitest';
 import { upgradeExecutorFetchPrivilegedAccounts } from './upgradeExecutorFetchPrivilegedAccounts';
 import {
   UPGRADE_EXECUTOR_ROLE_ADMIN,
@@ -6,6 +6,7 @@ import {
   upgradeExecutorEncodeFunctionData,
 } from './upgradeExecutorEncodeFunctionData';
 import { createPublicClient, http } from 'viem';
+import { getEarliestRollupCreatorDeploymentBlockNumber } from './utils/getEarliestRollupCreatorDeploymentBlockNumber';
 import { arbitrum } from 'viem/chains';
 
 const publicClient = createPublicClient({
@@ -41,4 +42,35 @@ it('it fetches the right privileged accounts from an UpgradeExecutor', async () 
   expect(Object.keys(privilegedAccounts).length).toEqual(2);
   expect(privilegedAccounts[upgradeExecutorAddress]).toEqual([UPGRADE_EXECUTOR_ROLE_ADMIN]);
   expect(privilegedAccounts[chainOwner]).toEqual([UPGRADE_EXECUTOR_ROLE_EXECUTOR]);
+});
+
+it('batches the getLogs queries when the RPC rejects the full range (#642)', async () => {
+  const batchingClient = createPublicClient({ chain: arbitrum, transport: http() });
+
+  // keep the batched range tiny and network-free
+  const lowerLimit = getEarliestRollupCreatorDeploymentBlockNumber(batchingClient);
+  batchingClient.getBlockNumber = vi.fn().mockResolvedValue(lowerLimit + 3n);
+
+  const upgradeExecutorAddress = '0x0611b78A42903a537BE7a2f9a8783BE39AC63cD9';
+  const account = '0x46A78349aBA0369D18292a285DE6d5FC5CC2de5c';
+  const roleGrantedLog = { args: { role: UPGRADE_EXECUTOR_ROLE_EXECUTOR, account } };
+
+  const getLogsMock = vi.fn();
+  batchingClient.getLogs = getLogsMock;
+  getLogsMock
+    // RoleGranted: full-range rejected, then the batched call returns the event
+    .mockRejectedValueOnce(new Error('query range is too big'))
+    .mockResolvedValueOnce([roleGrantedLog])
+    // RoleRevoked: full-range rejected, then the batched call returns nothing
+    .mockRejectedValueOnce(new Error('query range is too big'))
+    .mockResolvedValue([]);
+
+  const privilegedAccounts = await upgradeExecutorFetchPrivilegedAccounts({
+    upgradeExecutorAddress,
+    publicClient: batchingClient,
+  });
+
+  // the full-range attempt for each event is retried in batches rather than thrown
+  expect(getLogsMock.mock.calls.length).toBeGreaterThanOrEqual(4);
+  expect(privilegedAccounts[account]).toEqual([UPGRADE_EXECUTOR_ROLE_EXECUTOR]);
 });

--- a/src/upgradeExecutorFetchPrivilegedAccounts.ts
+++ b/src/upgradeExecutorFetchPrivilegedAccounts.ts
@@ -1,6 +1,7 @@
 import { Address, PublicClient, Transport, Chain } from 'viem';
 import { AbiEvent } from 'abitype';
 import { UpgradeExecutorRole } from './upgradeExecutorEncodeFunctionData';
+import { getLogsWithBatching } from './utils/getLogsWithBatching';
 
 /**
  * This type is for the params of the {@link upgradeExecutorFetchPrivilegedAccounts} function
@@ -97,11 +98,10 @@ export async function upgradeExecutorFetchPrivilegedAccounts<TChain extends Chai
   const upgradeExecutorPrivilegedAccounts: UpgradeExecutorPrivilegedAccounts = {};
 
   // 1. Find the RoleGranted events
-  const roleGrantedEvents = await publicClient.getLogs({
+  const roleGrantedEvents = await getLogsWithBatching(publicClient, {
     address: upgradeExecutorAddress,
     event: RoleGrantedEventAbi,
     fromBlock: 0n,
-    toBlock: 'latest',
   });
   if (!roleGrantedEvents || roleGrantedEvents.length <= 0) {
     // No roles have been granted
@@ -120,11 +120,10 @@ export async function upgradeExecutorFetchPrivilegedAccounts<TChain extends Chai
   });
 
   // 3. Find the RoleRevoked events
-  const roleRevokedEvents = await publicClient.getLogs({
+  const roleRevokedEvents = await getLogsWithBatching(publicClient, {
     address: upgradeExecutorAddress,
     event: RoleRevokedEventAbi,
     fromBlock: 0n,
-    toBlock: 'latest',
   });
   if (!roleRevokedEvents || roleRevokedEvents.length <= 0) {
     return upgradeExecutorPrivilegedAccounts;


### PR DESCRIPTION
closes #642

## what

`upgradeExecutorFetchPrivilegedAccounts` fetched the `RoleGranted` and `RoleRevoked` events with a single `getLogs({ fromBlock: 0n, toBlock: 'latest' })` per event. Most RPC providers cap `eth_getLogs` to a bounded block range, so this fails with "query range is too big" on nearly every endpoint (including `https://sepolia-rollup.arbitrum.io/rpc`), making the function unusable there.

## how

Use `getLogsWithBatching`, the helper the other fetchers already use (`getBatchPosters`, `getValidators`, `getKeysets`, `createRollupFetchCoreContracts`). It attempts the full range first and, on failure, falls back to fixed-size (9,999-block) batches from the latest block down to the rollup-creator deployment block, so it works against range-limited RPCs while staying fast on permissive ones.

## tests

Added a unit test that mocks the RPC to reject the full-range query and asserts the function batches (rather than throwing) and returns the correct privileged account. It fails against the previous implementation.

- `test:unit` (vitest) passes, `tsc`, `eslint`, `prettier --check` clean.
