### PR TITLE
fix: audit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,10 @@ overrides:
   tmp: 0.2.7
   vite>esbuild: 0.28.1
   vite: 7.3.5
-  vite>postcss: 8.5.18
-  brace-expansion: 5.0.8
+  vite>postcss: 8.5.23
+  postcss>nanoid: 3.3.18
+  '@eslint/eslintrc>js-yaml': 4.3.1
+  brace-expansion: 5.0.9
   minimatch: 10.2.5
 
 importers:
@@ -1214,8 +1216,8 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -1894,8 +1896,8 @@ packages:
   js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -2092,8 +2094,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.13:
-    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2276,8 +2278,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postinstall-postinstall@2.1.0:
@@ -3026,7 +3028,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.2.4
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 10.2.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3830,7 +3832,7 @@ snapshots:
 
   bn.js@5.2.3: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4761,7 +4763,7 @@ snapshots:
 
   js-sha3@0.8.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -4918,7 +4920,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -4926,7 +4928,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.13: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -5128,9 +5130,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.13
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5567,7 +5569,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rollup: 4.62.1
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,15 +65,23 @@ overrides:
   # (launch-editor UNC path handling) while staying on the existing 7.x line.
   "vite": "7.3.5"
 
-  # GHSA-6g55-p6wh-862q and GHSA-r28c-9q8g-f849 (source-map path traversal
-  # and file disclosure): vulnerable <=8.5.17, patched in 8.5.18. Scope this
-  # to Vite, the only PostCSS parent in the workspace.
-  "vite>postcss": "8.5.18"
+  # GHSA-6g55-p6wh-862q, GHSA-r28c-9q8g-f849, and GHSA-fxqj-rqcc-2cmp
+  # (source-map path traversal and file disclosure): vulnerable <=8.5.22,
+  # patched in 8.5.23. Scope this to Vite, the only PostCSS parent here.
+  "vite>postcss": "8.5.23"
 
-  # GHSA-mh99-v99m-4gvg (unbounded brace expansion DoS): all releases through
-  # 5.0.7 are vulnerable, and 5.0.8 is the only release currently recognized
-  # as patched by the advisory database.
-  "brace-expansion": "5.0.8"
+  # GHSA-28wg-ghj8-5hjv and GHSA-2v37-7h3g-55p8 (infinite loops for invalid
+  # generator sizes): the nanoid 3.x line is patched in 3.3.18. PostCSS is the
+  # only nanoid parent in the workspace, so keep the override scoped to it.
+  "postcss>nanoid": "3.3.18"
+
+  # GHSA-5p4m-2wfm-xmqj (quadratic CPU consumption while resolving !!omap):
+  # js-yaml 4.x is patched in 4.3.1. ESLint's eslintrc package accepts ^4.1.1.
+  "@eslint/eslintrc>js-yaml": "4.3.1"
+
+  # GHSA-mh99-v99m-4gvg and GHSA-rgw5-rvv9-x895 (unbounded brace expansion
+  # DoS): the complete fix for both advisories is available in 5.0.9.
+  "brace-expansion": "5.0.9"
 
   # Older minimatch major lines expect incompatible brace-expansion CommonJS
   # exports. All workspace consumers use the Minimatch constructor, which is

--- a/src/utils/getArbOSVersion.unit.test.ts
+++ b/src/utils/getArbOSVersion.unit.test.ts
@@ -10,7 +10,7 @@ it('returns the ArbOS version of Arbitrum One', async () => {
     transport: http(),
   });
 
-  expect(await getArbOSVersion(arbitrumOneClient)).toBe(51);
+  expect(await getArbOSVersion(arbitrumOneClient)).toBe(61);
 });
 
 it('throws if the chain is not an Arbitrum chain', async () => {


### PR DESCRIPTION
## Summary

- Update scoped dependency overrides for patched PostCSS, nanoid, js-yaml, and brace-expansion releases.
- Update the Arbitrum One ArbOS version assertion from 51 to 61.

## Why / Context

- Newly reported advisories require newer patched transitive dependency versions for the audit CI check.
- Arbitrum One was upgraded to version 61, making the previous unit-test expectation stale.