### PR TITLE
feat: generate genesis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-ARG NITRO_NODE_TAG=v3.9.8-4624977
+ARG NITRO_NODE_TAG=v3.11.3-beb2108
 ARG FOUNDRY_IMAGE=ghcr.io/foundry-rs/foundry:v1.3.1
 
 FROM offchainlabs/nitro-node:${NITRO_NODE_TAG} AS nitro
 FROM ${FOUNDRY_IMAGE} AS foundry
+
+FROM node:24-bookworm-slim AS genesis-file-generator
+ARG GENESIS_FILE_GENERATOR_VERSION=0.0.4
+WORKDIR /generator
+RUN npm install --omit=dev --ignore-scripts --no-save --package-lock=false \
+  "@arbitrum/genesis-file-generator@${GENESIS_FILE_GENERATOR_VERSION}"
 
 FROM node:20-bookworm-slim AS builder
 
@@ -17,13 +23,16 @@ RUN pnpm install --offline --frozen-lockfile --ignore-scripts
 RUN pnpm build
 RUN pnpm deploy --filter=@arbitrum/chain-sdk --prod --legacy --ignore-scripts /deployed
 
-FROM node:20-bookworm-slim AS runtime
+FROM node:24-bookworm-slim AS runtime
 
 ENV NODE_ENV=production
 WORKDIR /app
 
 COPY --from=builder --chown=node:node /deployed/dist ./dist
 COPY --from=builder --chown=node:node /deployed/node_modules ./node_modules
+COPY --from=genesis-file-generator --chown=node:node \
+  /generator/node_modules/@arbitrum/genesis-file-generator \
+  ./node_modules/@arbitrum/genesis-file-generator
 
 COPY --from=nitro /usr/local/bin/genesis-generator /usr/local/bin/genesis-generator
 COPY --from=foundry /usr/local/bin/cast /usr/local/bin/cast

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Make sure you are using Node.js v18 or greater.
 pnpm add @arbitrum/chain-sdk viem@^1.20.0
 ```
 
+### Custom genesis generation
+
+Genesis generation is intentionally not exposed as an SDK function: there is no `generateGenesis` export in `@arbitrum/chain-sdk`. The `generateGenesis` CLI command requires the external `genesis-generator` binary and `@arbitrum/genesis-file-generator`, which are bundled only in the Docker image and are not included in the SDK's npm package. Run this command using the Docker image.
+
 ## CLI
 
 The SDK ships a CLI that exposes its functions, workflows, and contract calls as subcommands. Each command takes a single JSON argument and prints a JSON result. Useful from shell scripts, CI, or any non-TypeScript caller.

--- a/src/generateGenesis.ts
+++ b/src/generateGenesis.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { isHash } from 'viem';
+
+export type GenerateGenesisParameters = {
+  chainId: string;
+  isAnyTrust?: string;
+  arbosVersion: string;
+  chainOwner: string;
+  l1BaseFee: string;
+  loadDefaultPredeploys?: string;
+  enableNativeTokenSupply?: string;
+  enableTransactionFiltering?: string;
+  customAllocAccountFile?: string;
+  maxCodeSize: string;
+  maxInitCodeSize: string;
+};
+
+export type GenerateGenesisResult = {
+  genesis: Record<string, unknown>;
+  blockHash: `0x${string}`;
+  sendRoot: `0x${string}`;
+};
+
+type GeneratorModule = {
+  generateGenesis: (options: GenerateGenesisParameters) => Record<string, unknown>;
+};
+
+const packageName = '@arbitrum/genesis-file-generator';
+
+export function parseGenesisGeneratorOutput(
+  output: string,
+): Pick<GenerateGenesisResult, 'blockHash' | 'sendRoot'> {
+  const [blockHashSegment, sendRootSegment] = output.split(',', 2);
+  const blockHash = blockHashSegment?.split('BlockHash: ')[1];
+  const sendRoot = sendRootSegment?.trim().split('SendRoot: ')[1];
+
+  if (!blockHash || !sendRoot || !isHash(blockHash) || !isHash(sendRoot)) {
+    throw new Error('genesis-generator returned an unexpected result.');
+  }
+
+  return { blockHash, sendRoot };
+}
+
+export async function generateGenesis(
+  options: GenerateGenesisParameters,
+): Promise<GenerateGenesisResult> {
+  let generator: GeneratorModule;
+  try {
+    generator = (await import(packageName)) as GeneratorModule;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'MODULE_NOT_FOUND' && code !== 'ERR_MODULE_NOT_FOUND') throw error;
+    throw new Error('generateGenesis is only available in the chain-sdk Docker image.');
+  }
+
+  const genesis = generator.generateGenesis(options);
+  const directory = mkdtempSync(join(tmpdir(), 'chain-sdk-genesis-'));
+  const genesisPath = join(directory, 'genesis.json');
+
+  try {
+    writeFileSync(genesisPath, JSON.stringify(genesis));
+    const globalState = execFileSync('genesis-generator', ['--genesis-json-file', genesisPath], {
+      encoding: 'utf8',
+    });
+
+    return { genesis, ...parseGenesisGeneratorOutput(globalState) };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}

--- a/src/generateGenesis.ts
+++ b/src/generateGenesis.ts
@@ -45,6 +45,11 @@ export function parseGenesisGeneratorOutput(
   return { blockHash, sendRoot };
 }
 
+/**
+ * Docker CLI-only: intentionally not exported from the SDK's public entry point.
+ * Requires the external `genesis-generator` binary and
+ * `@arbitrum/genesis-file-generator`, bundled only in the Docker image, not in the SDK's npm package.
+ */
 export async function generateGenesis(
   options: GenerateGenesisParameters,
 ): Promise<GenerateGenesisResult> {

--- a/src/scripting/commands.ts
+++ b/src/scripting/commands.ts
@@ -57,6 +57,7 @@ import {
   getConsensusReleaseByVersionSchema,
   getConsensusReleaseByWasmModuleRootSchema,
   isKnownWasmModuleRootSchema,
+  generateGenesisSchema,
 } from './schemas';
 
 import { getValidators } from '../getValidators';
@@ -142,6 +143,7 @@ import {
 } from './workflows/deployParentChainContracts';
 import { getNitroContractVersions } from '../getNitroContractVersions';
 import { getNitroContractVersionsSchema } from './schemas/getNitroContractVersions';
+import { generateGenesis } from '../generateGenesis';
 
 import { contractRegistry } from './contractRegistry';
 import { buildContractCommandSchema } from './contractCommandSchema';
@@ -387,4 +389,5 @@ export const commands: readonly Command[] = [
 
   ...contractCommands,
   command('getNitroContractVersions', getNitroContractVersionsSchema, getNitroContractVersions),
+  command('generateGenesis', generateGenesisSchema, generateGenesis),
 ];

--- a/src/scripting/schemaCoverage.ts
+++ b/src/scripting/schemaCoverage.ts
@@ -440,6 +440,9 @@ vi.mock('viem', async (importOriginal) => {
 vi.mock('../getNitroContractVersions', () => ({
   getNitroContractVersions: _mocks.fn('getNitroContractVersions'),
 }));
+vi.mock('../generateGenesis', () => ({
+  generateGenesis: _mocks.fn('generateGenesis'),
+}));
 /**
  * A testable leaf of a schema -- a scalar field the harness will vary when
  * running coverage.

--- a/src/scripting/schemas/generateGenesis.ts
+++ b/src/scripting/schemas/generateGenesis.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+import { type GenerateGenesisParameters } from '../../generateGenesis';
+import { addressSchema, bigintSchema } from './common';
+
+const optionalBooleanString = (value: boolean | undefined) =>
+  value === undefined ? undefined : String(value);
+
+export const generateGenesisSchema = z
+  .object({
+    chainId: bigintSchema,
+    arbosVersion: bigintSchema,
+    chainOwner: addressSchema,
+    l1BaseFee: bigintSchema,
+    isAnyTrust: z.boolean().optional(),
+    loadDefaultPredeploys: z.boolean().optional(),
+    enableNativeTokenSupply: z.boolean().optional(),
+    enableTransactionFiltering: z.boolean().optional(),
+    customAllocAccountFile: z.string().min(1).optional(),
+    maxCodeSize: bigintSchema.prefault('24576'),
+    maxInitCodeSize: bigintSchema.prefault('49152'),
+  })
+  .strict()
+  .transform((input): [GenerateGenesisParameters] => [
+    {
+      chainId: input.chainId.toString(),
+      arbosVersion: input.arbosVersion.toString(),
+      chainOwner: input.chainOwner,
+      l1BaseFee: input.l1BaseFee.toString(),
+      isAnyTrust: optionalBooleanString(input.isAnyTrust),
+      loadDefaultPredeploys: optionalBooleanString(input.loadDefaultPredeploys),
+      enableNativeTokenSupply: optionalBooleanString(input.enableNativeTokenSupply),
+      enableTransactionFiltering: optionalBooleanString(input.enableTransactionFiltering),
+      customAllocAccountFile: input.customAllocAccountFile,
+      maxCodeSize: input.maxCodeSize.toString(),
+      maxInitCodeSize: input.maxInitCodeSize.toString(),
+    },
+  ]);

--- a/src/scripting/schemas/index.ts
+++ b/src/scripting/schemas/index.ts
@@ -85,3 +85,4 @@ export {
   isAllowedSchema,
 } from './actions';
 export { getNitroContractVersionsSchema } from './getNitroContractVersions';
+export { generateGenesisSchema } from './generateGenesis';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "lib": ["ES2021"],
     "target": "ES2021",
     "types": ["node"],
+    "module": "commonjs",
 
     "moduleResolution": "node",
 


### PR DESCRIPTION
<!-- av pr stack begin -->
<table><tr><td><details><summary>This PR is part of a stack created with <a href="https://github.com/aviator-co/av">Aviator</a>.</summary>

* **#750**
* ➡️ **#748**
* `main`
</details></td></tr></table>
<!-- av pr stack end -->


## Summary

- Add a `generateGenesis` CLI command that creates an Orbit chain genesis configuration and derives its block hash and send root with Nitro's `genesis-generator`.
- Add a strict CLI schema for genesis parameters, including defaults for maximum code and init-code sizes.
- Install `@arbitrum/genesis-file-generator` in the chain SDK Docker image.
- Update the image to Nitro `v3.11.3-beb2108` and a Node 24 Bookworm runtime.

## Why / Context

This extends the Docker image introduced by the parent branch with the tooling required to generate chain genesis artifacts through the chain SDK CLI.

The implementation uses `@arbitrum/genesis-file-generator` to create the genesis configuration, then invokes Nitro's `genesis-generator` to calculate and validate the corresponding block hash and send root. 

Genesis generation is intentionally limited to the Docker image because the required package and Nitro binary are bundled there rather than added to the published SDK dependencies.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
