### PR TITLE
feat: add upgrade action to CLI

### DIFF
--- a/src/scripting/commands.ts
+++ b/src/scripting/commands.ts
@@ -58,6 +58,9 @@ import {
   getConsensusReleaseByWasmModuleRootSchema,
   isKnownWasmModuleRootSchema,
   generateGenesisSchema,
+  deployNitroContractsUpgradeActionSchema,
+  executeNitroContractsUpgradeSchema,
+  verifyNitroContractsUpgradeSchema,
 } from './schemas';
 
 import { getValidators } from '../getValidators';
@@ -144,6 +147,11 @@ import {
 import { getNitroContractVersions } from '../getNitroContractVersions';
 import { getNitroContractVersionsSchema } from './schemas/getNitroContractVersions';
 import { generateGenesis } from '../generateGenesis';
+import {
+  deployNitroContractsUpgradeAction,
+  executeNitroContractsUpgrade,
+  verifyNitroContractsUpgrade,
+} from '../nitroContractsUpgrade';
 
 import { contractRegistry } from './contractRegistry';
 import { buildContractCommandSchema } from './contractCommandSchema';
@@ -390,4 +398,19 @@ export const commands: readonly Command[] = [
   ...contractCommands,
   command('getNitroContractVersions', getNitroContractVersionsSchema, getNitroContractVersions),
   command('generateGenesis', generateGenesisSchema, generateGenesis),
+  command(
+    'deployNitroContractsUpgradeAction',
+    deployNitroContractsUpgradeActionSchema,
+    deployNitroContractsUpgradeAction,
+  ),
+  command(
+    'executeNitroContractsUpgrade',
+    executeNitroContractsUpgradeSchema,
+    executeNitroContractsUpgrade,
+  ),
+  command(
+    'verifyNitroContractsUpgrade',
+    verifyNitroContractsUpgradeSchema,
+    verifyNitroContractsUpgrade,
+  ),
 ];

--- a/src/scripting/schemaCoverage.ts
+++ b/src/scripting/schemaCoverage.ts
@@ -443,6 +443,11 @@ vi.mock('../getNitroContractVersions', () => ({
 vi.mock('../generateGenesis', () => ({
   generateGenesis: _mocks.fn('generateGenesis'),
 }));
+vi.mock('../nitroContractsUpgrade', () => ({
+  deployNitroContractsUpgradeAction: _mocks.fn('deployNitroContractsUpgradeAction'),
+  executeNitroContractsUpgrade: _mocks.fn('executeNitroContractsUpgrade'),
+  verifyNitroContractsUpgrade: _mocks.fn('verifyNitroContractsUpgrade'),
+}));
 /**
  * A testable leaf of a schema -- a scalar field the harness will vary when
  * running coverage.

--- a/src/scripting/schemas/index.ts
+++ b/src/scripting/schemas/index.ts
@@ -86,3 +86,8 @@ export {
 } from './actions';
 export { getNitroContractVersionsSchema } from './getNitroContractVersions';
 export { generateGenesisSchema } from './generateGenesis';
+export {
+  deployNitroContractsUpgradeActionSchema,
+  executeNitroContractsUpgradeSchema,
+  verifyNitroContractsUpgradeSchema,
+} from './nitroContractsUpgrade';

--- a/src/scripting/schemas/nitroContractsUpgrade.ts
+++ b/src/scripting/schemas/nitroContractsUpgrade.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+import type {
+  DeployNitroContractsUpgradeActionParameters,
+  ExecuteNitroContractsUpgradeParameters,
+  NitroContractsUpgradeVersion,
+  VerifyNitroContractsUpgradeParameters,
+} from '../../nitroContractsUpgrade';
+import { addressSchema } from './common';
+
+const nitroContractsUpgradeVersionSchema = z
+  .literal('3.2.0')
+  .transform((version) => version as NitroContractsUpgradeVersion);
+
+const deployNitroContractsUpgradeActionParamsSchema = z.strictObject({
+  version: nitroContractsUpgradeVersionSchema,
+  parentChainRpcUrl: z.url(),
+  forgeArgs: z.array(z.string()).optional(),
+});
+
+export const deployNitroContractsUpgradeActionSchema =
+  deployNitroContractsUpgradeActionParamsSchema.transform(
+    (params): [DeployNitroContractsUpgradeActionParameters] => [params],
+  );
+
+export const executeNitroContractsUpgradeSchema = deployNitroContractsUpgradeActionParamsSchema
+  .extend({
+    rollupAddress: addressSchema,
+    parentUpgradeExecutorAddress: addressSchema,
+    upgradeActionAddress: addressSchema,
+  })
+  .transform((params): [ExecuteNitroContractsUpgradeParameters] => [params]);
+
+export const verifyNitroContractsUpgradeSchema = deployNitroContractsUpgradeActionParamsSchema
+  .extend({
+    rollupAddress: addressSchema,
+  })
+  .transform((params): [VerifyNitroContractsUpgradeParameters] => [params]);

--- a/src/scripting/schemas/nitroContractsUpgrade.ts
+++ b/src/scripting/schemas/nitroContractsUpgrade.ts
@@ -1,27 +1,18 @@
 import { z } from 'zod';
 
-import type {
-  DeployNitroContractsUpgradeActionParameters,
-  ExecuteNitroContractsUpgradeParameters,
-  NitroContractsUpgradeVersion,
-  VerifyNitroContractsUpgradeParameters,
-} from '../../nitroContractsUpgrade';
-import { addressSchema } from './common';
+import { withParentChainPublicClient, withParentChainSign } from '../viemTransforms';
+import { addressSchema, parentChainPublicClientSchema, privateKeySchema } from './common';
 
-const nitroContractsUpgradeVersionSchema = z
-  .literal('3.2.0')
-  .transform((version) => version as NitroContractsUpgradeVersion);
+const nitroContractsUpgradeParamsSchema = parentChainPublicClientSchema.extend({
+  version: z.literal('3.2.0'),
+});
 
-const deployNitroContractsUpgradeActionParamsSchema = z.strictObject({
-  version: nitroContractsUpgradeVersionSchema,
-  parentChainRpcUrl: z.url(),
-  forgeArgs: z.array(z.string()).optional(),
+const deployNitroContractsUpgradeActionParamsSchema = nitroContractsUpgradeParamsSchema.extend({
+  privateKey: privateKeySchema,
 });
 
 export const deployNitroContractsUpgradeActionSchema =
-  deployNitroContractsUpgradeActionParamsSchema.transform(
-    (params): [DeployNitroContractsUpgradeActionParameters] => [params],
-  );
+  deployNitroContractsUpgradeActionParamsSchema.transform(withParentChainSign);
 
 export const executeNitroContractsUpgradeSchema = deployNitroContractsUpgradeActionParamsSchema
   .extend({
@@ -29,10 +20,10 @@ export const executeNitroContractsUpgradeSchema = deployNitroContractsUpgradeAct
     parentUpgradeExecutorAddress: addressSchema,
     upgradeActionAddress: addressSchema,
   })
-  .transform((params): [ExecuteNitroContractsUpgradeParameters] => [params]);
+  .transform(withParentChainSign);
 
-export const verifyNitroContractsUpgradeSchema = deployNitroContractsUpgradeActionParamsSchema
+export const verifyNitroContractsUpgradeSchema = nitroContractsUpgradeParamsSchema
   .extend({
     rollupAddress: addressSchema,
   })
-  .transform((params): [VerifyNitroContractsUpgradeParameters] => [params]);
+  .transform(withParentChainPublicClient);


### PR DESCRIPTION
## Summary

- Add CLI commands to deploy, execute, and verify Nitro contract upgrades.
- Add schemas restricted to version `3.2.0`, using signing transforms for deployment and execution and a public client for verification.

## Why / Context

Expose the existing Nitro contract upgrade functions through the CLI so operators can deploy an upgrade action, execute it, and verify the result.