### PR TITLE
chore: bump foundry and genesis-generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ARG NITRO_NODE_TAG=v3.11.3-beb2108
-ARG FOUNDRY_IMAGE=ghcr.io/foundry-rs/foundry:v1.3.1
+ARG FOUNDRY_IMAGE=ghcr.io/foundry-rs/foundry:v1.8.1
 
 FROM offchainlabs/nitro-node:${NITRO_NODE_TAG} AS nitro
 FROM ${FOUNDRY_IMAGE} AS foundry
 
 FROM node:24-bookworm-slim AS genesis-file-generator
-ARG GENESIS_FILE_GENERATOR_VERSION=0.0.4
+ARG GENESIS_FILE_GENERATOR_VERSION=0.0.5
 WORKDIR /generator
 RUN npm install --omit=dev --ignore-scripts --no-save --package-lock=false \
   "@arbitrum/genesis-file-generator@${GENESIS_FILE_GENERATOR_VERSION}"


### PR DESCRIPTION
## Summary
- Bump the Dockerfile’s Foundry image from v1.3.1 to v1.8.1.
- Bump @arbitrum/genesis-file-generator from 0.0.4 to 0.0.5.

## Why / Context
Update the Foundry tools and genesis file generator bundled in the chain SDK Docker image.